### PR TITLE
  feat(batch): 동시성 제어를 위한 가게 정보 배치 로직 개선

### DIFF
--- a/src/main/java/app/domain/batch/config/BulkJobConfig.java
+++ b/src/main/java/app/domain/batch/config/BulkJobConfig.java
@@ -8,6 +8,7 @@ import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import app.domain.batch.dto.BulkDto;
@@ -44,6 +45,9 @@ public class BulkJobConfig {
 			.reader(bulkReader)
 			.processor(bulkProcessor)
 			.writer(bulkWriter)
+			.faultTolerant()
+			.retryLimit(3)
+			.retry(DuplicateKeyException.class)
 			.build();
 	}
 

--- a/src/main/java/app/domain/batch/job/BulkWriter.java
+++ b/src/main/java/app/domain/batch/job/BulkWriter.java
@@ -1,5 +1,6 @@
 package app.domain.batch.job;
 
+import app.domain.mongo.model.entity.StoreCollection;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
@@ -8,7 +9,10 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Component;
-import app.domain.mongo.model.entity.StoreCollection;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.springframework.data.mongodb.core.query.Criteria.where;
 
@@ -24,11 +28,27 @@ public class BulkWriter implements ItemWriter<StoreCollection> {
 			return;
 		}
 
+		List<String> storeKeys = chunk.getItems().stream()
+				.map(StoreCollection::getStoreKey)
+				.toList();
+
+		Query versionQuery = new Query(where("storeKey").in(storeKeys));
+		versionQuery.fields().include("storeKey").include("version");
+
+		List<StoreCollection> existingStores = mongoTemplate.find(versionQuery, StoreCollection.class, "stores");
+
+		Map<String, Long> versionMap = existingStores.stream()
+				.collect(Collectors.toMap(StoreCollection::getStoreKey, StoreCollection::getVersion));
+
+		for (StoreCollection item : chunk) {
+			item.setVersion(versionMap.get(item.getStoreKey()));
+		}
+
 		String collectionName = "stores";
 		BulkOperations bulkOps = mongoTemplate.bulkOps(BulkOperations.BulkMode.UNORDERED, collectionName);
 
 		for (StoreCollection item : chunk) {
-			Query query = new Query(where("storeKey").is(item.getStoreKey()));
+			Query query = new Query(where("storeKey").is(item.getStoreKey()).and("version").is(item.getVersion()));
 
 			Update update = new Update();
 			update.set("userId", item.getUserId());
@@ -49,11 +69,11 @@ public class BulkWriter implements ItemWriter<StoreCollection> {
 			update.set("deletedAt", item.getDeletedAt());
 			update.set("menus", item.getMenus());
 			update.set("reviewCount", item.getReviewCount());
-
 			update.inc("version", 1);
 
 			bulkOps.upsert(query, update);
 		}
+
 		bulkOps.execute();
 	}
 }


### PR DESCRIPTION
  설명

  가게 정보(Store)를 동기화하는 Spring Batch 작업의 안정성과 성능을 개선하기 위해, 동시성 제어 로직을 추가하고 데이터 조회 방식을 최적화했습니다.

  기존 문제점

   1. 데이터 정합성 문제 (동시성 제어 부재)
       - 기존 배치 작업은 여러 인스턴스에서 동시에 실행되거나, 배치 작업이 실행되는 중에 운영자가 데이터를 직접 수정할 경우 데이터가 덮어씌워지는 유실 업데이트(Lost Update)
         문제가 발생할 수 있었습니다.
       - 데이터의 최종 상태를 보장할 수 없어 데이터 정합성에 잠재적인 위험이 있었습니다.

   2. 성능 저하 가능성 (N+1 쿼리 문제)
       - 만약 동시성 제어를 위해 각 데이터(Item)를 처리할 때마다 DB에서 version을 조회한다면, 청크(Chunk) 크기만큼의 쿼리가 매번 발생하여 심각한 성능 저하를 유발하는 N+1 
         문제가 발생합니다.

  해결 방안

   1. 낙관적 락(Optimistic Locking) 도입으로 데이터 정합성 확보
       - MongoDB의 StoreCollection에 version 필드를 활용하여 동시성 제어 문제를 해결했습니다.
       - BulkWriter는 데이터를 업데이트할 때, 자신이 읽었던 시점의 version과 DB의 version이 일치하는 경우에만 수정을 허용합니다.
       - 만약 version이 일치하지 않으면(다른 곳에서 먼저 수정된 경우), 업데이트는 실패하고 예외가 발생하여 데이터가 꼬이는 것을 원천적으로 방지합니다.

   2. 배치 성능 최적화 (N+1 문제 해결)
       - BulkWriter의 로직을 개선하여, 처리할 데이터 묶음(Chunk) 전체에 필요한 version 정보를 단 한 번의 쿼리로 가져오도록 구현했습니다.
       - 이로써 아이템마다 DB에 접근할 필요가 없어졌으며, N+1 문제를 해결하여 대용량 데이터 처리 시에도 높은 성능을 유지할 수 있습니다.

   3. 안정적인 예외 처리 및 자동 재시도
       - BulkJobConfig의 배치 스텝(Step)에 faultTolerant 설정을 추가했습니다.
       - 버전 충돌로 인해 DuplicateKeyException이 발생하면, Spring Batch가 이를 감지하고 자동으로 해당 Chunk를 재시도하도록 설정하여 배치의 안정성과 성공률을 높였습니다.

  주요 변경 내역

   - `BulkWriter.java`:
       - Chunk 단위로 version 정보를 한 번에 조회하는 로직 추가.
       - 조회된 version을 각 아이템에 설정하고, upsert 쿼리에 version 조건을 포함.
   - `BulkJobConfig.java`:
       - storeBatchStep에 .faultTolerant(), .retryLimit(), .retry() 설정을 추가하여 재시도 로직 구현.