### PR TITLE
Set default MongoDB database name to 'store-db'

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -7,7 +7,7 @@ spring:
   data:
     mongodb:
       host: ${MONGODB_HOST}
-      database: ${MONGO_NAME}
+      database: ${MONGO_NAME:store-db}
       username: ${MONGO_INITDB_ROOT_USERNAME}
       password: ${MONGO_INITDB_ROOT_PASSWORD}
 


### PR DESCRIPTION
## 🔥 Related Issues

- close #이슈번호

## 👍 작업 내용

- [x] ~ 기능 구현
- [x] ~ 페이지 구조화 및 스타일링

## ✅ PR Point

- 무슨 이유로 어떻게 코드를 변경했는지
- 어떤 위험이나 우려가 발견되었는지
- 어떤 부분에 리뷰어가 집중해야 하는지


## 📚 Reference**
**
- 구현에 참고한 링크 (필요한 경우만 작성하고 없으면 지우기)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - 프로덕션 구성에서 MongoDB 데이터베이스 이름에 기본값(store-db)을 도입하여 환경변수 미설정 시에도 서비스가 정상 기동되도록 개선했습니다. 배포 과정의 안정성이 높아지고, 초기 설정 누락으로 인한 시작 실패와 예기치 않은 오류를 줄여 운영 장애를 예방합니다.
- Style
  - 설정 파일의 포맷을 소폭 정리해 일관성을 개선했습니다. 기능상의 변화는 없으며, 가독성과 유지보수성이 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->